### PR TITLE
Updated to re-request SMS permission when denied

### DIFF
--- a/src/screens/permissions/index.js
+++ b/src/screens/permissions/index.js
@@ -1,4 +1,4 @@
-import { Button, SafeAreaView, ScrollView, Text, View } from 'react-native';
+import { Button, NativeModules, PermissionsAndroid, SafeAreaView, ScrollView, Text, View } from 'react-native';
 import React, { useState } from 'react';
 import { go } from '@pngme/react-native-sms-pngme-android';
 import Checkbox from 'expo-checkbox';
@@ -15,8 +15,29 @@ const Permissions = ({ navigation }) => {
     navigation.navigate('LoanApplication');
   };
 
-  const handleContinue = async () => {
-    if (toggleCheckBox) {
+  // Here we check if permission can be asked again, if user clicks on `never ask again` it will return false
+  const canPermissionBeAskedAgain = async() => {
+    try {
+      const canIt = await NativeModules.PermissionsAndroid.shouldShowRequestPermissionRationale(PermissionsAndroid.PERMISSIONS.READ_SMS)
+      return canIt;
+    } catch(e) {
+      return true
+    }
+  }
+
+  const requestSMSPermission = async () => {
+    try {
+      await PermissionsAndroid.request(
+        PermissionsAndroid.PERMISSIONS.READ_SMS
+      );
+    } catch (err) {
+      console.warn(err);
+    }
+  };
+
+  const handleContinue = async() => {
+    if (toggleCheckBox && !user.pngmePermissionWasSelected) {
+      // if user confirm they want to use Pngme, we store that selection
       setUser({ pngmePermissionWasSelected: true });
       await go({
         clientKey: Constants.manifest.extra.pngmeSdkToken,
@@ -27,12 +48,16 @@ const Permissions = ({ navigation }) => {
         isKycVerified: false,
         companyName: 'Acme Bank',
         externalId: '',
+        hidePngmeDialog: false, // if you want to hide the Pngme dialog, set this to true
       });
-      navigateToLoanScreen();
-    } else {
-      navigateToLoanScreen();
+    } else if (toggleCheckBox && user.pngmePermissionWasSelected) {
+      const reRequestSMSPermission = await canPermissionBeAskedAgain();
+      if (reRequestSMSPermission) {
+        await requestSMSPermission();
+      }
     }
-  };
+    navigateToLoanScreen();
+  }
 
   const renderCheckboxLine = (label, isSelected, onValueChange, disabled = false) => (
     <View style={styles.checkboxContainer}>


### PR DESCRIPTION
[PROD-704](https://pngme-app.atlassian.net/browse/PROD-704): update sample apps - default to re-request SMS consent

- Updated the `src/screens/permissions/index.js` file to re-request SMS permission
    - Permission is re-requested only when it's currently denied
- Had to include `user.pngmePermissionWasSelected` in the `if/else` checks. If not, if the permission is denied in the very first flow, it gets re-requested as soon as they go to the next screen. Felt this to be a very weird behavior and this was the workaround

Tested for the following cases:
- Permissions granted in the first flow -> Expected behavior ✅
- Permissions denied in the first flow -> gets re-requested upon every subsequent "Apply for a loan" flow, until granted -> Expected behavior ✅
- Permissions granted in the first flow -> Then, permission is denied via the Settings -> gets re-requested, until granted -> Expected behavior ✅

⚠️ The permission popup (during re-request) looks slightly different than the current one - there's a new "Deny & don't ask again" option along with the "Allow" and "Deny" options.
Looks like this version of the permission pop-up is the default in newer Android versions. If/when we update the SDK, we would see the similar behavior